### PR TITLE
Replace OpenBlasSharp Dgemm with ILNumerics ManagedLAPACK in double GEMM tests

### DIFF
--- a/MatFlatTest/BlasTests.MulMatMatDouble.cs
+++ b/MatFlatTest/BlasTests.MulMatMatDouble.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Linq;
+using ILNumerics.F2NET;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_MulMatMatDouble
     {
+        private static readonly ManagedLAPACK Blas = new ManagedLAPACK();
+
         [TestCase(1, 1, 1, 1, 1, 1)]
         [TestCase(1, 1, 1, 2, 3, 4)]
         [TestCase(2, 2, 2, 2, 2, 2)]
@@ -29,9 +32,8 @@ namespace MatFlatTest
             fixed (double* pb = b)
             fixed (double* pc = expected)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                Blas.dgemm(
+                    'N', 'N',
                     m, n, k,
                     1.0,
                     pa, lda,
@@ -71,9 +73,8 @@ namespace MatFlatTest
             fixed (double* pb = b)
             fixed (double* pc = expected)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                Blas.dgemm(
+                    'T', 'N',
                     m, n, k,
                     1.0,
                     pa, lda,
@@ -113,9 +114,8 @@ namespace MatFlatTest
             fixed (double* pb = b)
             fixed (double* pc = expected)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.Trans,
+                Blas.dgemm(
+                    'N', 'T',
                     m, n, k,
                     1.0,
                     pa, lda,
@@ -155,9 +155,8 @@ namespace MatFlatTest
             fixed (double* pb = b)
             fixed (double* pc = expected)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.Trans,
+                Blas.dgemm(
+                    'T', 'T',
                     m, n, k,
                     1.0,
                     pa, lda,

--- a/MatFlatTest/MatFlatTest.csproj
+++ b/MatFlatTest/MatFlatTest.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ILNumerics.ONAL" Version="0.9.3" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Motivation
- Remove the dependency on `OpenBlasSharp` for expected-value generation in the double GEMM tests by using ILNumerics' managed BLAS/LAPACK implementation. 
- Make the `BlasTests_MulMatMatDouble` self-contained so it can run without native OpenBLAS binaries.

### Description
- Replaced the four `OpenBlasSharp.Blas.Dgemm` calls in `MatFlatTest/BlasTests.MulMatMatDouble.cs` with `ILNumerics.F2NET.ManagedLAPACK.dgemm` calls and added a `private static readonly ManagedLAPACK Blas = new ManagedLAPACK();` helper. 
- Added `using ILNumerics.F2NET;` to the test file and added a package reference to `ILNumerics.ONAL` in `MatFlatTest/MatFlatTest.csproj` so the managed LAPACK wrapper is available. 
- Files changed: `MatFlatTest/BlasTests.MulMatMatDouble.cs` and `MatFlatTest/MatFlatTest.csproj`.

### Testing
- Ran the targeted test command `PATH=/tmp/dotnet10:$PATH DOTNET_ROOT=/tmp/dotnet10 dotnet test MatFlatTest/MatFlatTest.csproj --filter FullyQualifiedName~MatFlatTest.BlasTests_MulMatMatDouble` and the run reported `Passed: 39, Failed: 0, Skipped: 0` for the matched tests. 
- Other tests in the suite were not executed because they still require native OpenBLAS binaries and were intentionally skipped per the change request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca95035788326bdbf4ebda89abf92)