### PR TITLE
Remove OpenBlasSharp dependency from complex matrix-matrix tests

### DIFF
--- a/MatFlatTest/BlasTests.MulMatMatComplex.cs
+++ b/MatFlatTest/BlasTests.MulMatMatComplex.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
+using MatFlat;
 
 namespace MatFlatTest
 {
@@ -23,37 +24,20 @@ namespace MatFlatTest
         {
             for (var cond = 0; cond < 4; cond++)
             {
-                var (obTrans1, obTrans2, mfTrans1, mfTrans2) = GetCondition(false, false, cond);
+                var (trans1, trans2) = GetCondition(false, false, cond);
 
                 var a = Matrix.RandomComplex(42, m, k, lda);
                 var b = Matrix.RandomComplex(57, k, n, ldb);
                 var c = Matrix.RandomComplex(0, m, n, ldc);
-
                 var expected = c.ToArray();
-                fixed (Complex* pa = a)
-                fixed (Complex* pb = b)
-                fixed (Complex* pc = expected)
-                {
-                    var one = Complex.One;
-                    var zero = Complex.Zero;
-
-                    OpenBlasSharp.Blas.Zgemm(
-                        OpenBlasSharp.Order.ColMajor,
-                        obTrans1, obTrans2,
-                        m, n, k,
-                        &one,
-                        pa, lda,
-                        pb, ldb,
-                        &zero,
-                        pc, ldc);
-                }
+                MulMatMat(trans1, trans2, m, n, k, a, lda, b, ldb, expected, ldc);
 
                 var actual = c.ToArray();
                 fixed (Complex* pa = a)
                 fixed (Complex* pb = b)
                 fixed (Complex* pc = actual)
                 {
-                    MatFlat.Blas.MulMatMat(mfTrans1, mfTrans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                    Blas.MulMatMat(trans1, trans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
                 }
 
                 Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -74,37 +58,20 @@ namespace MatFlatTest
         {
             for (var cond = 0; cond < 4; cond++)
             {
-                var (obTrans1, obTrans2, mfTrans1, mfTrans2) = GetCondition(true, false, cond);
+                var (trans1, trans2) = GetCondition(true, false, cond);
 
                 var a = Matrix.RandomComplex(42, k, m, lda);
                 var b = Matrix.RandomComplex(57, k, n, ldb);
                 var c = Matrix.RandomComplex(0, m, n, ldc);
-
                 var expected = c.ToArray();
-                fixed (Complex* pa = a)
-                fixed (Complex* pb = b)
-                fixed (Complex* pc = expected)
-                {
-                    var one = Complex.One;
-                    var zero = Complex.Zero;
-
-                    OpenBlasSharp.Blas.Zgemm(
-                        OpenBlasSharp.Order.ColMajor,
-                        obTrans1, obTrans2,
-                        m, n, k,
-                        &one,
-                        pa, lda,
-                        pb, ldb,
-                        &zero,
-                        pc, ldc);
-                }
+                MulMatMat(trans1, trans2, m, n, k, a, lda, b, ldb, expected, ldc);
 
                 var actual = c.ToArray();
                 fixed (Complex* pa = a)
                 fixed (Complex* pb = b)
                 fixed (Complex* pc = actual)
                 {
-                    MatFlat.Blas.MulMatMat(mfTrans1, mfTrans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                    Blas.MulMatMat(trans1, trans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
                 }
 
                 Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -125,37 +92,20 @@ namespace MatFlatTest
         {
             for (var cond = 0; cond < 4; cond++)
             {
-                var (obTrans1, obTrans2, mfTrans1, mfTrans2) = GetCondition(false, true, cond);
+                var (trans1, trans2) = GetCondition(false, true, cond);
 
                 var a = Matrix.RandomComplex(42, m, k, lda);
                 var b = Matrix.RandomComplex(57, n, k, ldb);
                 var c = Matrix.RandomComplex(0, m, n, ldc);
-
                 var expected = c.ToArray();
-                fixed (Complex* pa = a)
-                fixed (Complex* pb = b)
-                fixed (Complex* pc = expected)
-                {
-                    var one = Complex.One;
-                    var zero = Complex.Zero;
-
-                    OpenBlasSharp.Blas.Zgemm(
-                        OpenBlasSharp.Order.ColMajor,
-                        obTrans1, obTrans2,
-                        m, n, k,
-                        &one,
-                        pa, lda,
-                        pb, ldb,
-                        &zero,
-                        pc, ldc);
-                }
+                MulMatMat(trans1, trans2, m, n, k, a, lda, b, ldb, expected, ldc);
 
                 var actual = c.ToArray();
                 fixed (Complex* pa = a)
                 fixed (Complex* pb = b)
                 fixed (Complex* pc = actual)
                 {
-                    MatFlat.Blas.MulMatMat(mfTrans1, mfTrans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                    Blas.MulMatMat(trans1, trans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
                 }
 
                 Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -176,37 +126,20 @@ namespace MatFlatTest
         {
             for (var cond = 0; cond < 4; cond++)
             {
-                var (obTrans1, obTrans2, mfTrans1, mfTrans2) = GetCondition(true, true, cond);
+                var (trans1, trans2) = GetCondition(true, true, cond);
 
                 var a = Matrix.RandomComplex(42, k, m, lda);
                 var b = Matrix.RandomComplex(57, n, k, ldb);
                 var c = Matrix.RandomComplex(0, m, n, ldc);
-
                 var expected = c.ToArray();
-                fixed (Complex* pa = a)
-                fixed (Complex* pb = b)
-                fixed (Complex* pc = expected)
-                {
-                    var one = Complex.One;
-                    var zero = Complex.Zero;
-
-                    OpenBlasSharp.Blas.Zgemm(
-                        OpenBlasSharp.Order.ColMajor,
-                        obTrans1, obTrans2,
-                        m, n, k,
-                        &one,
-                        pa, lda,
-                        pb, ldb,
-                        &zero,
-                        pc, ldc);
-                }
+                MulMatMat(trans1, trans2, m, n, k, a, lda, b, ldb, expected, ldc);
 
                 var actual = c.ToArray();
                 fixed (Complex* pa = a)
                 fixed (Complex* pb = b)
                 fixed (Complex* pc = actual)
                 {
-                    MatFlat.Blas.MulMatMat(mfTrans1, mfTrans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                    Blas.MulMatMat(trans1, trans2, m, n, k, pa, lda, pb, ldb, pc, ldc);
                 }
 
                 Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -214,64 +147,67 @@ namespace MatFlatTest
             }
         }
 
-        private static (OpenBlasSharp.Transpose, OpenBlasSharp.Transpose, MatFlat.Transpose, MatFlat.Transpose) GetCondition(bool transa, bool transb, int cond)
+        private static void MulMatMat(Transpose transa, Transpose transb, int m, int n, int k, Complex[] a, int lda, Complex[] b, int ldb, Complex[] c, int ldc)
+        {
+            for (var j = 0; j < n; j++)
+            {
+                for (var i = 0; i < m; i++)
+                {
+                    var sum = Complex.Zero;
+                    for (var l = 0; l < k; l++)
+                    {
+                        sum += GetElement(a, lda, i, l, transa) * GetElement(b, ldb, l, j, transb);
+                    }
+                    c[i + j * ldc] = sum;
+                }
+            }
+        }
+
+        private static Complex GetElement(Complex[] x, int ldx, int row, int col, Transpose trans)
+        {
+            var value = trans == Transpose.NoTrans || trans == Transpose.ConjNoTrans
+                ? x[row + col * ldx]
+                : x[col + row * ldx];
+
+            return trans == Transpose.ConjNoTrans || trans == Transpose.ConjTrans
+                ? Complex.Conjugate(value)
+                : value;
+        }
+
+        private static (Transpose, Transpose) GetCondition(bool transa, bool transb, int cond)
         {
             switch (cond)
             {
                 case 0:
                     return (
-                        transa ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans,
-                        transb ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans,
-                        transa ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans,
-                        transb ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans);
+                        transa ? Transpose.Trans : Transpose.NoTrans,
+                        transb ? Transpose.Trans : Transpose.NoTrans);
                 case 1:
                     return (
-                        AddConj(transa ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans),
-                        transb ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans,
-                        AddConj(transa ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans),
-                        transb ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans);
+                        AddConj(transa ? Transpose.Trans : Transpose.NoTrans),
+                        transb ? Transpose.Trans : Transpose.NoTrans);
                 case 2:
                     return (
-                        transa ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans,
-                        AddConj(transb ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans),
-                        transa ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans,
-                        AddConj(transb ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans));
+                        transa ? Transpose.Trans : Transpose.NoTrans,
+                        AddConj(transb ? Transpose.Trans : Transpose.NoTrans));
                 case 3:
                     return (
-                        AddConj(transa ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans),
-                        AddConj(transb ? OpenBlasSharp.Transpose.Trans : OpenBlasSharp.Transpose.NoTrans),
-                        AddConj(transa ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans),
-                        AddConj(transb ? MatFlat.Transpose.Trans : MatFlat.Transpose.NoTrans));
+                        AddConj(transa ? Transpose.Trans : Transpose.NoTrans),
+                        AddConj(transb ? Transpose.Trans : Transpose.NoTrans));
                 default:
                     throw new Exception();
             }
         }
 
-        private static OpenBlasSharp.Transpose AddConj(OpenBlasSharp.Transpose trans)
+        private static Transpose AddConj(Transpose trans)
         {
-            if (trans == OpenBlasSharp.Transpose.NoTrans)
+            if (trans == Transpose.NoTrans)
             {
-                return OpenBlasSharp.Transpose.ConjNoTrans;
+                return Transpose.ConjNoTrans;
             }
-            else if (trans == OpenBlasSharp.Transpose.Trans)
+            else if (trans == Transpose.Trans)
             {
-                return OpenBlasSharp.Transpose.ConjTrans;
-            }
-            else
-            {
-                throw new Exception();
-            }
-        }
-
-        private static MatFlat.Transpose AddConj(MatFlat.Transpose trans)
-        {
-            if (trans == MatFlat.Transpose.NoTrans)
-            {
-                return MatFlat.Transpose.ConjNoTrans;
-            }
-            else if (trans == MatFlat.Transpose.Trans)
-            {
-                return MatFlat.Transpose.ConjTrans;
+                return Transpose.ConjTrans;
             }
             else
             {


### PR DESCRIPTION
### Motivation
- Make the complex matrix-matrix BLAS tests independent from the `OpenBlasSharp` native provider so they can run without OpenBLAS binaries.
- Simplify tests by using project types and APIs directly (avoid repeatedly fully-qualified `MatFlat...` names).
- Provide a small, self-contained reference implementation inside the test to compute expected results for complex `MulMatMat` with transpose and conjugation variants.

### Description
- Added `using MatFlat;` and removed fully-qualified `MatFlat.*` usages so test code calls `Blas` and `Transpose` unqualified.
- Replaced `OpenBlasSharp.Blas.Zgemm` expected-value generation with an in-test column-major reference implementation `MulMatMat` plus element accessor `GetElement` that respects `Transpose` and conjugation.
- Simplified `GetCondition` and `AddConj` helpers to return `MatFlat.Transpose` values only, removing all `OpenBlasSharp` and `OpenBlasSharp.Transpose` references.
- Kept the existing assertion tolerances (`1.0E-12`) unchanged.

### Testing
- Ran the specific test filter with .NET 10 using `DOTNET_ROOT=/tmp/dotnet10 PATH=/tmp/dotnet10:$PATH dotnet test MatFlatTest/MatFlatTest.csproj --filter FullyQualifiedName~BlasTests_MulMatMatComplex` and all matched tests passed. 
- Test run result: `Passed!  - Failed:     0, Passed:    39, Skipped:     0, Total:    39`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcad2e48d48326bd44d8c6727d666c)