### PR TITLE
Use ManagedLAPACK for complex triangular solve tests

### DIFF
--- a/MatFlatTest/BlasTests.SolveTriangularComplex.cs
+++ b/MatFlatTest/BlasTests.SolveTriangularComplex.cs
@@ -1,12 +1,73 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using ILNumerics;
+using ILNumerics.Core.Native;
+using ILNumerics.F2NET;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_SolveTriangularComplex
     {
+        private static readonly ILapack lapack = new ManagedLAPACK();
+
+        private static unsafe void FakeZtrsv(char uplo, char transA, int n, Complex* a, int lda, Complex* x, int incx)
+        {
+            // ManagedLAPACK does not support OpenBLAS' ConjNoTrans mode, so this
+            // test helper treats '!' as "conjugate without transpose".
+            var aCopy = new Complex[lda * n];
+            for (var i = 0; i < aCopy.Length; i++)
+            {
+                aCopy[i] = a[i];
+            }
+
+            if (transA == '!')
+            {
+                ConjugateInPlace(aCopy, n, n, lda);
+                transA = 'N';
+            }
+
+            var b = new Complex[n];
+            for (var i = 0; i < n; i++)
+            {
+                b[i] = x[i * incx];
+            }
+
+            var info = 0;
+            fixed (Complex* pa = aCopy)
+            fixed (Complex* pb = b)
+            {
+                lapack.ztrtrs(
+                    uplo, transA, 'N',
+                    n, 1,
+                    (complex*)pa, lda,
+                    (complex*)pb, n,
+                    ref info);
+            }
+
+            Assert.That(info, Is.EqualTo(0));
+
+            for (var i = 0; i < n; i++)
+            {
+                x[i * incx] = b[i];
+            }
+        }
+
+        private static void ConjugateInPlace(Complex[] a, int rows, int cols, int lda)
+        {
+            for (var col = 0; col < cols; col++)
+            {
+                for (var row = 0; row < rows; row++)
+                {
+                    var index = (col * lda) + row;
+                    var value = a[index];
+                    a[index] = new Complex(value.Real, -value.Imaginary);
+                }
+            }
+        }
+
         [TestCase(1, 1, 1)]
         [TestCase(1, 2, 3)]
         [TestCase(2, 2, 1)]
@@ -34,21 +95,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('U', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -82,21 +136,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('L', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -130,21 +177,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('U', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -178,21 +218,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('L', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -226,21 +259,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.ConjNoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('U', '!', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.ConjNoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.ConjNoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -274,21 +300,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.ConjTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('U', 'C', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.ConjTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.ConjTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -322,21 +341,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.ConjNoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('L', '!', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.ConjNoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.ConjNoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));
@@ -370,21 +382,14 @@ namespace MatFlatTest
             fixed (Complex* pa = a)
             fixed (Complex* px = expected)
             {
-                OpenBlasSharp.Blas.Ztrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.ConjTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeZtrsv('L', 'C', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (Complex* pa = a)
             fixed (Complex* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.ConjTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.ConjTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-11));


### PR DESCRIPTION
### Motivation

- Replace runtime dependency on `OpenBlasSharp` for complex triangular-solve test expectations by using the already-present `ManagedLAPACK` path used in other complex tests. 
- With the OpenBlasSharp-specific references removed, import the `MatFlat` namespace and simplify test code by removing redundant `MatFlat.` prefixes.

### Description

- Added a `ManagedLAPACK` instance (`ILapack lapack = new ManagedLAPACK()`) and a `FakeZtrsv` helper that invokes `lapack.ztrtrs` to compute expected RHS for complex triangular solves. 
- Implemented `ConjugateInPlace` and a small wrapper in `FakeZtrsv` to emulate OpenBLAS `ConjNoTrans` behavior when mapping to the LAPACK routine. 
- Replaced `OpenBlasSharp.Blas.Ztrsv(...)` calls in `BlasTests_SolveTriangularComplex` with `FakeZtrsv(...)` and removed `MatFlat.` prefixes so tests call `Blas.SolveTriangular(Uplo.*, Transpose.*, ...)` directly. 
- Added `using ILNumerics; using ILNumerics.Core.Native; using ILNumerics.F2NET; using MatFlat;` to the test file to support the above changes.

### Testing

- Ran `dotnet build MatFlatTest/MatFlatTest.csproj -v:minimal`, which succeeded.
- Ran `dotnet test MatFlatTest/MatFlatTest.csproj --no-build --filter FullyQualifiedName~BlasTests_SolveTriangularComplex -v:minimal`, and the filtered tests passed.
- Also ran `dotnet test` filtered for `BlasTests_MulMatMatComplex` to confirm the reference pattern, and that filtered test run passed.
- Other tests were intentionally skipped because they depend on OpenBLAS native binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feaacd78a88326822336a2dcfc13c9)