### PR TITLE
Replace OpenBlasSharp usage in selected BLAS tests with ManagedLAPACK and local helpers

### DIFF
--- a/MatFlatTest/BlasTests.MulMatMatSingle.cs
+++ b/MatFlatTest/BlasTests.MulMatMatSingle.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Linq;
+using ILNumerics.Core.Native;
+using ILNumerics.F2NET;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_MulMatMatSingle
     {
+        private static readonly ILapack lapack = new ManagedLAPACK();
+
         [TestCase(1, 1, 1, 1, 1, 1)]
         [TestCase(1, 1, 1, 2, 3, 4)]
         [TestCase(2, 2, 2, 2, 2, 2)]
@@ -29,9 +34,8 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = expected)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                lapack.sgemm(
+                    'N', 'N',
                     m, n, k,
                     1.0F,
                     pa, lda,
@@ -45,7 +49,7 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = actual)
             {
-                MatFlat.Blas.MulMatMat(MatFlat.Transpose.NoTrans, MatFlat.Transpose.NoTrans, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                Blas.MulMatMat(Transpose.NoTrans, Transpose.NoTrans, m, n, k, pa, lda, pb, ldb, pc, ldc);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -71,9 +75,8 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = expected)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                lapack.sgemm(
+                    'T', 'N',
                     m, n, k,
                     1.0F,
                     pa, lda,
@@ -87,7 +90,7 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = actual)
             {
-                MatFlat.Blas.MulMatMat(MatFlat.Transpose.Trans, MatFlat.Transpose.NoTrans, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                Blas.MulMatMat(Transpose.Trans, Transpose.NoTrans, m, n, k, pa, lda, pb, ldb, pc, ldc);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -113,9 +116,8 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = expected)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.Trans,
+                lapack.sgemm(
+                    'N', 'T',
                     m, n, k,
                     1.0F,
                     pa, lda,
@@ -129,7 +131,7 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = actual)
             {
-                MatFlat.Blas.MulMatMat(MatFlat.Transpose.NoTrans, MatFlat.Transpose.Trans, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                Blas.MulMatMat(Transpose.NoTrans, Transpose.Trans, m, n, k, pa, lda, pb, ldb, pc, ldc);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -155,9 +157,8 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = expected)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.Trans,
+                lapack.sgemm(
+                    'T', 'T',
                     m, n, k,
                     1.0F,
                     pa, lda,
@@ -171,7 +172,7 @@ namespace MatFlatTest
             fixed (float* pb = b)
             fixed (float* pc = actual)
             {
-                MatFlat.Blas.MulMatMat(MatFlat.Transpose.Trans, MatFlat.Transpose.Trans, m, n, k, pa, lda, pb, ldb, pc, ldc);
+                Blas.MulMatMat(Transpose.Trans, Transpose.Trans, m, n, k, pa, lda, pb, ldb, pc, ldc);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));

--- a/MatFlatTest/BlasTests.MulMatVecComplex.cs
+++ b/MatFlatTest/BlasTests.MulMatVecComplex.cs
@@ -1,12 +1,55 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_MulMatVecComplex
     {
+        private static unsafe void FakeZgemv(char transA, int m, int n, Complex* a, int lda, Complex* x, int incx, Complex* y, int incy)
+        {
+            if (transA == 'N' || transA == '!')
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    var sum = Complex.Zero;
+                    for (var col = 0; col < n; col++)
+                    {
+                        var value = a[(col * lda) + row];
+                        if (transA == '!')
+                        {
+                            value = Complex.Conjugate(value);
+                        }
+
+                        sum += value * x[col * incx];
+                    }
+
+                    y[row * incy] = sum;
+                }
+            }
+            else
+            {
+                for (var col = 0; col < n; col++)
+                {
+                    var sum = Complex.Zero;
+                    for (var row = 0; row < m; row++)
+                    {
+                        var value = a[(col * lda) + row];
+                        if (transA == 'C')
+                        {
+                            value = Complex.Conjugate(value);
+                        }
+
+                        sum += value * x[row * incx];
+                    }
+
+                    y[col * incy] = sum;
+                }
+            }
+        }
+
         [TestCase(1, 1, 1, 1, 1)]
         [TestCase(1, 1, 3, 2, 4)]
         [TestCase(2, 2, 2, 1, 1)]
@@ -32,18 +75,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = expected)
             {
-                var one = Complex.One;
-                var zero = Complex.Zero;
-
-                OpenBlasSharp.Blas.Zgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    m, n,
-                    &one,
-                    pa, lda,
-                    px, incx,
-                    &zero,
-                    py, incy);
+                FakeZgemv('N', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -51,7 +83,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -83,18 +115,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = expected)
             {
-                var one = Complex.One;
-                var zero = Complex.Zero;
-
-                OpenBlasSharp.Blas.Zgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans,
-                    m, n,
-                    &one,
-                    pa, lda,
-                    px, incx,
-                    &zero,
-                    py, incy);
+                FakeZgemv('T', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -102,7 +123,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -134,18 +155,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = expected)
             {
-                var one = Complex.One;
-                var zero = Complex.Zero;
-
-                OpenBlasSharp.Blas.Zgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjNoTrans,
-                    m, n,
-                    &one,
-                    pa, lda,
-                    px, incx,
-                    &zero,
-                    py, incy);
+                FakeZgemv('!', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -153,7 +163,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.ConjNoTrans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.ConjNoTrans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -185,18 +195,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = expected)
             {
-                var one = Complex.One;
-                var zero = Complex.Zero;
-
-                OpenBlasSharp.Blas.Zgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans,
-                    m, n,
-                    &one,
-                    pa, lda,
-                    px, incx,
-                    &zero,
-                    py, incy);
+                FakeZgemv('C', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -204,7 +203,7 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.ConjTrans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.ConjTrans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));

--- a/MatFlatTest/BlasTests.MulMatVecDouble.cs
+++ b/MatFlatTest/BlasTests.MulMatVecDouble.cs
@@ -1,11 +1,42 @@
 ﻿using System;
 using System.Linq;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_MulMatVecDouble
     {
+        private static unsafe void FakeDgemv(char transA, int m, int n, double* a, int lda, double* x, int incx, double* y, int incy)
+        {
+            if (transA == 'N')
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    var sum = 0.0;
+                    for (var col = 0; col < n; col++)
+                    {
+                        sum += a[(col * lda) + row] * x[col * incx];
+                    }
+
+                    y[row * incy] = sum;
+                }
+            }
+            else
+            {
+                for (var col = 0; col < n; col++)
+                {
+                    var sum = 0.0;
+                    for (var row = 0; row < m; row++)
+                    {
+                        sum += a[(col * lda) + row] * x[row * incx];
+                    }
+
+                    y[col * incy] = sum;
+                }
+            }
+        }
+
         [TestCase(1, 1, 1, 1, 1)]
         [TestCase(1, 1, 3, 2, 4)]
         [TestCase(2, 2, 2, 1, 1)]
@@ -31,15 +62,7 @@ namespace MatFlatTest
             fixed (double* px = x)
             fixed (double* py = expected)
             {
-                OpenBlasSharp.Blas.Dgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    m, n,
-                    1.0,
-                    pa, lda,
-                    px, incx,
-                    0.0,
-                    py, incy);
+                FakeDgemv('N', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -47,7 +70,7 @@ namespace MatFlatTest
             fixed (double* px = x)
             fixed (double* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));
@@ -78,15 +101,7 @@ namespace MatFlatTest
             fixed (double* px = x)
             fixed (double* py = expected)
             {
-                OpenBlasSharp.Blas.Dgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans,
-                    m, n,
-                    1.0,
-                    pa, lda,
-                    px, incx,
-                    0.0,
-                    py, incy);
+                FakeDgemv('T', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -94,7 +109,7 @@ namespace MatFlatTest
             fixed (double* px = x)
             fixed (double* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));

--- a/MatFlatTest/BlasTests.MulMatVecSingle.cs
+++ b/MatFlatTest/BlasTests.MulMatVecSingle.cs
@@ -1,11 +1,42 @@
 ﻿using System;
 using System.Linq;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_MulMatVecSingle
     {
+        private static unsafe void FakeSgemv(char transA, int m, int n, float* a, int lda, float* x, int incx, float* y, int incy)
+        {
+            if (transA == 'N')
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    var sum = 0.0F;
+                    for (var col = 0; col < n; col++)
+                    {
+                        sum += a[(col * lda) + row] * x[col * incx];
+                    }
+
+                    y[row * incy] = sum;
+                }
+            }
+            else
+            {
+                for (var col = 0; col < n; col++)
+                {
+                    var sum = 0.0F;
+                    for (var row = 0; row < m; row++)
+                    {
+                        sum += a[(col * lda) + row] * x[row * incx];
+                    }
+
+                    y[col * incy] = sum;
+                }
+            }
+        }
+
         [TestCase(1, 1, 1, 1, 1)]
         [TestCase(1, 1, 3, 2, 4)]
         [TestCase(2, 2, 2, 1, 1)]
@@ -31,15 +62,7 @@ namespace MatFlatTest
             fixed (float* px = x)
             fixed (float* py = expected)
             {
-                OpenBlasSharp.Blas.Sgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    m, n,
-                    1.0F,
-                    pa, lda,
-                    px, incx,
-                    0.0F,
-                    py, incy);
+                FakeSgemv('N', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -47,7 +70,7 @@ namespace MatFlatTest
             fixed (float* px = x)
             fixed (float* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.NoTrans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-5));
@@ -78,15 +101,7 @@ namespace MatFlatTest
             fixed (float* px = x)
             fixed (float* py = expected)
             {
-                OpenBlasSharp.Blas.Sgemv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans,
-                    m, n,
-                    1.0F,
-                    pa, lda,
-                    px, incx,
-                    0.0F,
-                    py, incy);
+                FakeSgemv('T', m, n, pa, lda, px, incx, py, incy);
             }
 
             var actual = y.ToArray();
@@ -94,7 +109,7 @@ namespace MatFlatTest
             fixed (float* px = x)
             fixed (float* py = actual)
             {
-                MatFlat.Blas.MulMatVec(MatFlat.Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
+                Blas.MulMatVec(Transpose.Trans, m, n, pa, lda, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-5));

--- a/MatFlatTest/BlasTests.SolveTriangularDouble.cs
+++ b/MatFlatTest/BlasTests.SolveTriangularDouble.cs
@@ -1,12 +1,44 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using ILNumerics.Core.Native;
+using ILNumerics.F2NET;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_SolveTriangularDouble
     {
+        private static readonly ILapack lapack = new ManagedLAPACK();
+
+        private static unsafe void FakeDtrsv(char uplo, char transA, int n, double* a, int lda, double* x, int incx)
+        {
+            var b = new double[n];
+            for (var i = 0; i < n; i++)
+            {
+                b[i] = x[i * incx];
+            }
+
+            var info = 0;
+            fixed (double* pb = b)
+            {
+                lapack.dtrtrs(
+                    uplo, transA, 'N',
+                    n, 1,
+                    a, lda,
+                    pb, n,
+                    ref info);
+            }
+
+            Assert.That(info, Is.EqualTo(0));
+
+            for (var i = 0; i < n; i++)
+            {
+                x[i * incx] = b[i];
+            }
+        }
+
         [TestCase(1, 1, 1)]
         [TestCase(1, 2, 3)]
         [TestCase(2, 2, 1)]
@@ -34,21 +66,14 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* px = expected)
             {
-                OpenBlasSharp.Blas.Dtrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeDtrsv('U', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (double* pa = a)
             fixed (double* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-11));
@@ -81,21 +106,14 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* px = expected)
             {
-                OpenBlasSharp.Blas.Dtrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeDtrsv('L', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (double* pa = a)
             fixed (double* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-11));
@@ -128,21 +146,14 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* px = expected)
             {
-                OpenBlasSharp.Blas.Dtrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeDtrsv('U', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (double* pa = a)
             fixed (double* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-11));
@@ -175,21 +186,14 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* px = expected)
             {
-                OpenBlasSharp.Blas.Dtrsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeDtrsv('L', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (double* pa = a)
             fixed (double* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-11));

--- a/MatFlatTest/BlasTests.SolveTriangularSingle.cs
+++ b/MatFlatTest/BlasTests.SolveTriangularSingle.cs
@@ -1,12 +1,44 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using ILNumerics.Core.Native;
+using ILNumerics.F2NET;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_SolveTriangularSingle
     {
+        private static readonly ILapack lapack = new ManagedLAPACK();
+
+        private static unsafe void FakeStrsv(char uplo, char transA, int n, float* a, int lda, float* x, int incx)
+        {
+            var b = new float[n];
+            for (var i = 0; i < n; i++)
+            {
+                b[i] = x[i * incx];
+            }
+
+            var info = 0;
+            fixed (float* pb = b)
+            {
+                lapack.strtrs(
+                    uplo, transA, 'N',
+                    n, 1,
+                    a, lda,
+                    pb, n,
+                    ref info);
+            }
+
+            Assert.That(info, Is.EqualTo(0));
+
+            for (var i = 0; i < n; i++)
+            {
+                x[i * incx] = b[i];
+            }
+        }
+
         [TestCase(1, 1, 1)]
         [TestCase(1, 2, 3)]
         [TestCase(2, 2, 1)]
@@ -34,21 +66,14 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* px = expected)
             {
-                OpenBlasSharp.Blas.Strsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeStrsv('U', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (float* pa = a)
             fixed (float* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-3));
@@ -81,21 +106,14 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* px = expected)
             {
-                OpenBlasSharp.Blas.Strsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeStrsv('L', 'N', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (float* pa = a)
             fixed (float* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.NoTrans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.NoTrans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-3));
@@ -128,21 +146,14 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* px = expected)
             {
-                OpenBlasSharp.Blas.Strsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Upper,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeStrsv('U', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (float* pa = a)
             fixed (float* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Upper, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Upper, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-3));
@@ -175,21 +186,14 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* px = expected)
             {
-                OpenBlasSharp.Blas.Strsv(
-                    OpenBlasSharp.Order.ColMajor,
-                    OpenBlasSharp.Uplo.Lower,
-                    OpenBlasSharp.Transpose.Trans,
-                    OpenBlasSharp.Diag.NonUnit,
-                    n,
-                    pa, lda,
-                    px, incx);
+                FakeStrsv('L', 'T', n, pa, lda, px, incx);
             }
 
             var actual = input.ToArray();
             fixed (float* pa = a)
             fixed (float* px = actual)
             {
-                MatFlat.Blas.SolveTriangular(MatFlat.Uplo.Lower, MatFlat.Transpose.Trans, n, pa, lda, px, incx);
+                Blas.SolveTriangular(Uplo.Lower, Transpose.Trans, n, pa, lda, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-3));

--- a/MatFlatTest/BlasTests.VectorOperations.cs
+++ b/MatFlatTest/BlasTests.VectorOperations.cs
@@ -1,12 +1,116 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using MatFlat;
 using NUnit.Framework;
 
 namespace MatFlatTest
 {
     public class BlasTests_VectorOperations
     {
+        private static unsafe float FakeSnrm2(int n, float* x, int incx)
+        {
+            return MathF.Sqrt(FakeSdot(n, x, incx, x, incx));
+        }
+
+        private static unsafe double FakeDnrm2(int n, double* x, int incx)
+        {
+            return Math.Sqrt(FakeDdot(n, x, incx, x, incx));
+        }
+
+        private static unsafe double FakeDznrm2(int n, Complex* x, int incx)
+        {
+            return Math.Sqrt(FakeZdotc(n, x, incx, x, incx).Real);
+        }
+
+        private static unsafe float FakeSdot(int n, float* x, int incx, float* y, int incy)
+        {
+            var sum = 0.0F;
+            for (var i = 0; i < n; i++)
+            {
+                sum += x[i * incx] * y[i * incy];
+            }
+
+            return sum;
+        }
+
+        private static unsafe double FakeDdot(int n, double* x, int incx, double* y, int incy)
+        {
+            var sum = 0.0;
+            for (var i = 0; i < n; i++)
+            {
+                sum += x[i * incx] * y[i * incy];
+            }
+
+            return sum;
+        }
+
+        private static unsafe Complex FakeZdotu(int n, Complex* x, int incx, Complex* y, int incy)
+        {
+            var sum = Complex.Zero;
+            for (var i = 0; i < n; i++)
+            {
+                sum += x[i * incx] * y[i * incy];
+            }
+
+            return sum;
+        }
+
+        private static unsafe Complex FakeZdotc(int n, Complex* x, int incx, Complex* y, int incy)
+        {
+            var sum = Complex.Zero;
+            for (var i = 0; i < n; i++)
+            {
+                sum += Complex.Conjugate(x[i * incx]) * y[i * incy];
+            }
+
+            return sum;
+        }
+
+        private static unsafe void FakeSger(int m, int n, float* x, int incx, float* y, int incy, float* a, int lda)
+        {
+            for (var col = 0; col < n; col++)
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    a[(col * lda) + row] = x[row * incx] * y[col * incy];
+                }
+            }
+        }
+
+        private static unsafe void FakeDger(int m, int n, double* x, int incx, double* y, int incy, double* a, int lda)
+        {
+            for (var col = 0; col < n; col++)
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    a[(col * lda) + row] = x[row * incx] * y[col * incy];
+                }
+            }
+        }
+
+        private static unsafe void FakeZgeru(int m, int n, Complex* x, int incx, Complex* y, int incy, Complex* a, int lda)
+        {
+            for (var col = 0; col < n; col++)
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    a[(col * lda) + row] = x[row * incx] * y[col * incy];
+                }
+            }
+        }
+
+        private static unsafe void FakeZgerc(int m, int n, Complex* x, int incx, Complex* y, int incy, Complex* a, int lda)
+        {
+            for (var col = 0; col < n; col++)
+            {
+                for (var row = 0; row < m; row++)
+                {
+                    a[(col * lda) + row] = x[row * incx] * Complex.Conjugate(y[col * incy]);
+                }
+            }
+        }
+
         [TestCase(1, 1)]
         [TestCase(1, 2)]
         [TestCase(2, 1)]
@@ -22,13 +126,13 @@ namespace MatFlatTest
             float expected;
             fixed (float* px = x)
             {
-                expected = OpenBlasSharp.Blas.Snrm2(n, px, incx);
+                expected = FakeSnrm2(n, px, incx);
             }
 
             float actual;
             fixed (float* px = x)
             {
-                actual = MatFlat.Blas.L2Norm(n, px, incx);
+                actual = Blas.L2Norm(n, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -49,13 +153,13 @@ namespace MatFlatTest
             double expected;
             fixed (double* px = x)
             {
-                expected = OpenBlasSharp.Blas.Dnrm2(n, px, incx);
+                expected = FakeDnrm2(n, px, incx);
             }
 
             double actual;
             fixed (double* px = x)
             {
-                actual = MatFlat.Blas.L2Norm(n, px, incx);
+                actual = Blas.L2Norm(n, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));
@@ -76,13 +180,13 @@ namespace MatFlatTest
             double expected;
             fixed (Complex* px = x)
             {
-                expected = OpenBlasSharp.Blas.Dznrm2(n, px, incx);
+                expected = FakeDznrm2(n, px, incx);
             }
 
             double actual;
             fixed (Complex* px = x)
             {
-                actual = MatFlat.Blas.L2Norm(n, px, incx);
+                actual = Blas.L2Norm(n, px, incx);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));
@@ -105,14 +209,14 @@ namespace MatFlatTest
             fixed (float* px = x)
             fixed (float* py = y)
             {
-                expected = OpenBlasSharp.Blas.Sdot(n, px, incx, py, incy);
+                expected = FakeSdot(n, px, incx, py, incy);
             }
 
             float actual;
             fixed (float* px = x)
             fixed (float* py = y)
             {
-                actual = MatFlat.Blas.Dot(n, px, incx, py, incy);
+                actual = Blas.Dot(n, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -135,14 +239,14 @@ namespace MatFlatTest
             fixed (double* px = x)
             fixed (double* py = y)
             {
-                expected = OpenBlasSharp.Blas.Ddot(n, px, incx, py, incy);
+                expected = FakeDdot(n, px, incx, py, incy);
             }
 
             double actual;
             fixed (double* px = x)
             fixed (double* py = y)
             {
-                actual = MatFlat.Blas.Dot(n, px, incx, py, incy);
+                actual = Blas.Dot(n, px, incx, py, incy);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));
@@ -165,14 +269,14 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = y)
             {
-                expected = OpenBlasSharp.Blas.Zdotu(n, px, incx, py, incy);
+                expected = FakeZdotu(n, px, incx, py, incy);
             }
 
             Complex actual;
             fixed (Complex* px = x)
             fixed (Complex* py = y)
             {
-                actual = MatFlat.Blas.Dot(n, px, incx, py, incy);
+                actual = Blas.Dot(n, px, incx, py, incy);
             }
 
             Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(1.0E-12));
@@ -196,14 +300,14 @@ namespace MatFlatTest
             fixed (Complex* px = x)
             fixed (Complex* py = y)
             {
-                expected = OpenBlasSharp.Blas.Zdotc(n, px, incx, py, incy);
+                expected = FakeZdotc(n, px, incx, py, incy);
             }
 
             Complex actual;
             fixed (Complex* px = x)
             fixed (Complex* py = y)
             {
-                actual = MatFlat.Blas.DotConj(n, px, incx, py, incy);
+                actual = Blas.DotConj(n, px, incx, py, incy);
             }
 
             Assert.That(actual.Real, Is.EqualTo(expected.Real).Within(1.0E-12));
@@ -231,17 +335,7 @@ namespace MatFlatTest
             fixed (float* py = y)
             fixed (float* pa = expected)
             {
-                for (var j = 0; j < n; j++)
-                {
-                    new Span<float>(pa + lda * j, m).Clear();
-                }
-                OpenBlasSharp.Blas.Sger(
-                    OpenBlasSharp.Order.ColMajor,
-                    m, n,
-                    1.0F,
-                    px, incx,
-                    py, incy,
-                    pa, lda);
+                FakeSger(m, n, px, incx, py, incy, pa, lda);
             }
 
             var actual = a.ToArray();
@@ -249,7 +343,7 @@ namespace MatFlatTest
             fixed (float* py = y)
             fixed (float* pa = actual)
             {
-                MatFlat.Blas.Outer(m, n, px, incx, py, incy, pa, lda);
+                Blas.Outer(m, n, px, incx, py, incy, pa, lda);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-6));
@@ -276,17 +370,7 @@ namespace MatFlatTest
             fixed (double* py = y)
             fixed (double* pa = expected)
             {
-                for (var j = 0; j < n; j++)
-                {
-                    new Span<double>(pa + lda * j, m).Clear();
-                }
-                OpenBlasSharp.Blas.Dger(
-                    OpenBlasSharp.Order.ColMajor,
-                    m, n,
-                    1.0,
-                    px, incx,
-                    py, incy,
-                    pa, lda);
+                FakeDger(m, n, px, incx, py, incy, pa, lda);
             }
 
             var actual = a.ToArray();
@@ -294,7 +378,7 @@ namespace MatFlatTest
             fixed (double* py = y)
             fixed (double* pa = actual)
             {
-                MatFlat.Blas.Outer(m, n, px, incx, py, incy, pa, lda);
+                Blas.Outer(m, n, px, incx, py, incy, pa, lda);
             }
 
             Assert.That(actual, Is.EqualTo(expected).Within(1.0E-12));
@@ -321,19 +405,7 @@ namespace MatFlatTest
             fixed (Complex* py = y)
             fixed (Complex* pa = expected)
             {
-                var one = Complex.One;
-
-                for (var j = 0; j < n; j++)
-                {
-                    new Span<Complex>(pa + lda * j, m).Clear();
-                }
-                OpenBlasSharp.Blas.Zgeru(
-                    OpenBlasSharp.Order.ColMajor,
-                    m, n,
-                    &one,
-                    px, incx,
-                    py, incy,
-                    pa, lda);
+                FakeZgeru(m, n, px, incx, py, incy, pa, lda);
             }
 
             var actual = a.ToArray();
@@ -341,7 +413,7 @@ namespace MatFlatTest
             fixed (Complex* py = y)
             fixed (Complex* pa = actual)
             {
-                MatFlat.Blas.Outer(m, n, px, incx, py, incy, pa, lda);
+                Blas.Outer(m, n, px, incx, py, incy, pa, lda);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));
@@ -369,19 +441,7 @@ namespace MatFlatTest
             fixed (Complex* py = y)
             fixed (Complex* pa = expected)
             {
-                var one = Complex.One;
-
-                for (var j = 0; j < n; j++)
-                {
-                    new Span<Complex>(pa + lda * j, m).Clear();
-                }
-                OpenBlasSharp.Blas.Zgerc(
-                    OpenBlasSharp.Order.ColMajor,
-                    m, n,
-                    &one,
-                    px, incx,
-                    py, incy,
-                    pa, lda);
+                FakeZgerc(m, n, px, incx, py, incy, pa, lda);
             }
 
             var actual = a.ToArray();
@@ -389,7 +449,7 @@ namespace MatFlatTest
             fixed (Complex* py = y)
             fixed (Complex* pa = actual)
             {
-                MatFlat.Blas.OuterConj(m, n, px, incx, py, incy, pa, lda);
+                Blas.OuterConj(m, n, px, incx, py, incy, pa, lda);
             }
 
             Assert.That(actual.Select(x => x.Real), Is.EqualTo(expected.Select(x => x.Real)).Within(1.0E-12));


### PR DESCRIPTION
### Motivation
- Remove runtime dependency on `OpenBlasSharp` in several BLAS unit tests and use `ManagedLAPACK` or small local reference implementations so tests do not require OpenBLAS binaries. 
- Eliminate class/namespace collisions so `MatFlat` can be `using`-imported and `MatFlat...` prefixes removed throughout the edited tests.

### Description
- Replaced calls that computed expected results with OpenBlasSharp (e.g. `Sgemm`, `Dgemv`, `Zgemv`, `Dtrsv`, `Strsv`) by either `ManagedLAPACK` calls (`lapack.sgemm`, `lapack.*trtrs`) or by compact local `Fake*` helpers that implement the expected behavior for mat-vec, dot, norm and outer operations. 
- Imported the `MatFlat` namespace and simplified test calls from `MatFlat.Blas.*` / `MatFlat.Transpose.*` / `MatFlat.Uplo.*` to `Blas.*` / `Transpose.*` / `Uplo.*` where applicable. 
- Added small helper functions in tests: `FakeSgemv`/`FakeDgemv`/`FakeZgemv`, `FakeDtrsv`/`FakeStrsv`, scalar helpers for `dot`/`nrm2` and `Fake*ger`/`Fake*dot` variants to preserve stride and conjugation semantics used by the tests. 
- Kept original numerical tolerances in assertions; no tolerance changes were made as part of this refactor.

### Testing
- Ran code formatting with `dotnet format MatFlat.slnx --include <edited files> --no-restore` which completed successfully. 
- Executed the focused test set with `dotnet test MatFlatTest/MatFlatTest.csproj --no-restore --filter "FullyQualifiedName~BlasTests_MulMatMatSingle|FullyQualifiedName~BlasTests_MulMatVecComplex|FullyQualifiedName~BlasTests_MulMatVecDouble|FullyQualifiedName~BlasTests_MulMatVecSingle|FullyQualifiedName~BlasTests_SolveTriangularDouble|FullyQualifiedName~BlasTests_SolveTriangularSingle|FullyQualifiedName~BlasTests_VectorOperations"` and the run passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feae08ed1883269c05a061f005f09c)