### PR TITLE
Replace decomposition tests with ManagedLAPACK

### DIFF
--- a/MatFlatTest/CholeskyTests.cs
+++ b/MatFlatTest/CholeskyTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -28,8 +27,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (float* pa = expectedA)
             {
-                Lapack.Spotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                LapackTest.Spotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
             }
 
             var actualA = a.ToArray();
@@ -61,8 +60,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (float* pa = expectedA)
             {
-                var result = Lapack.Spotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                var result = LapackTest.Spotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
                 decomposable = result == 0;
             }
 
@@ -111,8 +110,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (double* pa = expectedA)
             {
-                Lapack.Dpotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                LapackTest.Dpotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
             }
 
             var actualA = a.ToArray();
@@ -144,8 +143,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (double* pa = expectedA)
             {
-                var result = Lapack.Dpotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                var result = LapackTest.Dpotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
                 decomposable = result == 0;
             }
 
@@ -194,8 +193,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (Complex* pa = expectedA)
             {
-                Lapack.Zpotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                LapackTest.Zpotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
             }
 
             var actualA = a.ToArray();
@@ -228,8 +227,8 @@ namespace MatFlatTest
             var expectedA = a.ToArray();
             fixed (Complex* pa = expectedA)
             {
-                var result = Lapack.Zpotrf(MatrixLayout.ColMajor, 'U', n, pa, lda);
-                OpenBlasResultToL(n, expectedA, lda);
+                var result = LapackTest.Zpotrf('U', n, pa, lda);
+                LapackResultToL(n, expectedA, lda);
                 decomposable = result == 0;
             }
 
@@ -268,10 +267,9 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0F,
                     pa, lda,
@@ -307,10 +305,9 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0,
                     pa, lda,
@@ -348,10 +345,9 @@ namespace MatFlatTest
             {
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.ConjTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.ConjTrans,
                     n, n, n,
                     &one,
                     pa, lda,
@@ -433,7 +429,7 @@ namespace MatFlatTest
             return a;
         }
 
-        private static void OpenBlasResultToL<T>(int n, T[] a, int lda) where T : unmanaged, INumberBase<T>
+        private static void LapackResultToL<T>(int n, T[] a, int lda) where T : unmanaged, INumberBase<T>
         {
             for (var row = 0; row < n; row++)
             {
@@ -458,7 +454,7 @@ namespace MatFlatTest
             }
         }
 
-        private static void OpenBlasResultToL(int n, Complex[] a, int lda)
+        private static void LapackResultToL(int n, Complex[] a, int lda)
         {
             for (var row = 0; row < n; row++)
             {

--- a/MatFlatTest/EvdTests.cs
+++ b/MatFlatTest/EvdTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -49,10 +48,9 @@ namespace MatFlatTest
             fixed (float* ptmp = tmp)
             fixed (float* preconstructed = reconstructed)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pv, lda,
@@ -60,10 +58,9 @@ namespace MatFlatTest
                     0.0F,
                     ptmp, n);
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0F,
                     ptmp, n,
@@ -133,10 +130,9 @@ namespace MatFlatTest
             fixed (double* ptmp = tmp)
             fixed (double* preconstructed = reconstructed)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pv, lda,
@@ -144,10 +140,9 @@ namespace MatFlatTest
                     0.0,
                     ptmp, n);
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0,
                     ptmp, n,
@@ -220,10 +215,9 @@ namespace MatFlatTest
                 var one = Complex.One;
                 var zero = Complex.Zero;
 
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pv, lda,
@@ -231,10 +225,9 @@ namespace MatFlatTest
                     &zero,
                     ptmp, n);
 
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.ConjTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.ConjTrans,
                     n, n, n,
                     &one,
                     ptmp, n,
@@ -274,10 +267,9 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0F,
                     pa, lda,
@@ -305,10 +297,9 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0,
                     pa, lda,
@@ -338,10 +329,9 @@ namespace MatFlatTest
             {
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.ConjTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.ConjTrans,
                     n, n, n,
                     &one,
                     pa, lda,

--- a/MatFlatTest/GevdTests.cs
+++ b/MatFlatTest/GevdTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -48,9 +47,8 @@ namespace MatFlatTest
             {
                 for (var j = 0; j < n; j++)
                 {
-                    OpenBlasSharp.Blas.Sgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Sgemv(
+                        Transpose.NoTrans,
                         n, n,
                         1.0F,
                         pa, lda,
@@ -58,9 +56,8 @@ namespace MatFlatTest
                         0.0F,
                         pl, 1);
 
-                    OpenBlasSharp.Blas.Sgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Sgemv(
+                        Transpose.NoTrans,
                         n, n,
                         w[j],
                         pb, ldb,
@@ -132,9 +129,8 @@ namespace MatFlatTest
             {
                 for (var j = 0; j < n; j++)
                 {
-                    OpenBlasSharp.Blas.Dgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Dgemv(
+                        Transpose.NoTrans,
                         n, n,
                         1.0,
                         pa, lda,
@@ -142,9 +138,8 @@ namespace MatFlatTest
                         0.0,
                         pl, 1);
 
-                    OpenBlasSharp.Blas.Dgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Dgemv(
+                        Transpose.NoTrans,
                         n, n,
                         w[j],
                         pb, ldb,
@@ -220,9 +215,8 @@ namespace MatFlatTest
                 {
                     var cw = (Complex)w[j];
 
-                    OpenBlasSharp.Blas.Zgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Zgemv(
+                        Transpose.NoTrans,
                         n, n,
                         &one,
                         pa, lda,
@@ -230,9 +224,8 @@ namespace MatFlatTest
                         &zero,
                         pl, 1);
 
-                    OpenBlasSharp.Blas.Zgemv(
-                        Order.ColMajor,
-                        OpenBlasSharp.Transpose.NoTrans,
+                    LapackTest.Zgemv(
+                        Transpose.NoTrans,
                         n, n,
                         &cw,
                         pb, ldb,
@@ -276,10 +269,9 @@ namespace MatFlatTest
             fixed (float* pa = a)
             fixed (float* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0F,
                     pa, lda,
@@ -307,10 +299,9 @@ namespace MatFlatTest
             fixed (double* pa = a)
             fixed (double* ps = symmetric)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.Trans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.Trans,
                     n, n, n,
                     1.0,
                     pa, lda,
@@ -340,10 +331,9 @@ namespace MatFlatTest
             {
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.ConjTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.ConjTrans,
                     n, n, n,
                     &one,
                     pa, lda,

--- a/MatFlatTest/LapackTest.cs
+++ b/MatFlatTest/LapackTest.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Numerics;
+using ILNumerics;
+using ILNumerics.Core.Native;
+using ILNumerics.F2NET;
+using MatFlat;
+
+namespace MatFlatTest
+{
+    internal static class LapackTest
+    {
+        private static readonly ILapack lapack = new ManagedLAPACK();
+
+        public static unsafe void Sgemm(Transpose transA, Transpose transB, int m, int n, int k, float alpha, float* a, int lda, float* b, int ldb, float beta, float* c, int ldc)
+        {
+            lapack.sgemm(ToLapackTranspose(transA), ToLapackTranspose(transB), m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+        }
+
+        public static unsafe void Dgemm(Transpose transA, Transpose transB, int m, int n, int k, double alpha, double* a, int lda, double* b, int ldb, double beta, double* c, int ldc)
+        {
+            lapack.dgemm(ToLapackTranspose(transA), ToLapackTranspose(transB), m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+        }
+
+        public static unsafe void Zgemm(Transpose transA, Transpose transB, int m, int n, int k, Complex* alpha, Complex* a, int lda, Complex* b, int ldb, Complex* beta, Complex* c, int ldc)
+        {
+            lapack.zgemm(ToLapackTranspose(transA), ToLapackTranspose(transB), m, n, k, ToLapackComplex(*alpha), (complex*)a, lda, (complex*)b, ldb, ToLapackComplex(*beta), (complex*)c, ldc);
+        }
+
+        public static unsafe void Sgemv(Transpose transA, int m, int n, float alpha, float* a, int lda, float* x, int incx, float beta, float* y, int incy)
+        {
+            if (incx != 1 || incy != 1)
+            {
+                throw new NotSupportedException("ManagedLAPACK-based gemv test helper only supports unit increments.");
+            }
+
+            var rows = transA == Transpose.NoTrans ? m : n;
+            var k = transA == Transpose.NoTrans ? n : m;
+            lapack.sgemm(ToLapackTranspose(transA), 'N', rows, 1, k, alpha, a, lda, x, k, beta, y, rows);
+        }
+
+        public static unsafe void Dgemv(Transpose transA, int m, int n, double alpha, double* a, int lda, double* x, int incx, double beta, double* y, int incy)
+        {
+            if (incx != 1 || incy != 1)
+            {
+                throw new NotSupportedException("ManagedLAPACK-based gemv test helper only supports unit increments.");
+            }
+
+            var rows = transA == Transpose.NoTrans ? m : n;
+            var k = transA == Transpose.NoTrans ? n : m;
+            lapack.dgemm(ToLapackTranspose(transA), 'N', rows, 1, k, alpha, a, lda, x, k, beta, y, rows);
+        }
+
+        public static unsafe void Zgemv(Transpose transA, int m, int n, Complex* alpha, Complex* a, int lda, Complex* x, int incx, Complex* beta, Complex* y, int incy)
+        {
+            if (incx != 1 || incy != 1)
+            {
+                throw new NotSupportedException("ManagedLAPACK-based gemv test helper only supports unit increments.");
+            }
+
+            var rows = transA == Transpose.NoTrans ? m : n;
+            var k = transA == Transpose.NoTrans ? n : m;
+            lapack.zgemm(ToLapackTranspose(transA), 'N', rows, 1, k, ToLapackComplex(*alpha), (complex*)a, lda, (complex*)x, k, ToLapackComplex(*beta), (complex*)y, rows);
+        }
+
+        public static unsafe int Sgetrf(int m, int n, float* a, int lda, int* piv)
+        {
+            var info = 0;
+            lapack.sgetrf(m, n, a, lda, piv, ref info);
+            return info;
+        }
+
+        public static unsafe int Dgetrf(int m, int n, double* a, int lda, int* piv)
+        {
+            var info = 0;
+            lapack.dgetrf(m, n, a, lda, piv, ref info);
+            return info;
+        }
+
+        public static unsafe int Zgetrf(int m, int n, Complex* a, int lda, int* piv)
+        {
+            var info = 0;
+            lapack.zgetrf(m, n, (complex*)a, lda, piv, ref info);
+            return info;
+        }
+
+        public static unsafe int Spotrf(char uplo, int n, float* a, int lda)
+        {
+            var info = 0;
+            lapack.spotrf(uplo, n, a, lda, ref info);
+            return info;
+        }
+
+        public static unsafe int Dpotrf(char uplo, int n, double* a, int lda)
+        {
+            var info = 0;
+            lapack.dpotrf(uplo, n, a, lda, ref info);
+            return info;
+        }
+
+        public static unsafe int Zpotrf(char uplo, int n, Complex* a, int lda)
+        {
+            var info = 0;
+            lapack.zpotrf(uplo, n, (complex*)a, lda, ref info);
+            return info;
+        }
+
+        private static char ToLapackTranspose(Transpose trans)
+        {
+            return trans switch
+            {
+                Transpose.NoTrans => 'N',
+                Transpose.Trans => 'T',
+                Transpose.ConjTrans => 'C',
+                _ => throw new ArgumentOutOfRangeException(nameof(trans), trans, null),
+            };
+        }
+
+        private static complex ToLapackComplex(Complex value)
+        {
+            return new complex(value.Real, value.Imaginary);
+        }
+    }
+}

--- a/MatFlatTest/LuInverseTests.cs
+++ b/MatFlatTest/LuInverseTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -33,10 +32,9 @@ namespace MatFlatTest
             {
                 Factorization.Lu(n, n, pa, lda, ppiv);
                 Factorization.LuInverse(n, pa, lda, ppiv);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     poriginal, lda,
@@ -96,10 +94,9 @@ namespace MatFlatTest
             {
                 Factorization.Lu(n, n, pa, lda, ppiv);
                 Factorization.LuInverse(n, pa, lda, ppiv);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     poriginal, lda,
@@ -162,10 +159,9 @@ namespace MatFlatTest
 
                 Factorization.Lu(n, n, pa, lda, ppiv);
                 Factorization.LuInverse(n, pa, lda, ppiv);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans,
-                    OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans,
+                    Transpose.NoTrans,
                     n, n, n,
                     &one,
                     poriginal, lda,

--- a/MatFlatTest/LuTests.cs
+++ b/MatFlatTest/LuTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -38,7 +37,7 @@ namespace MatFlatTest
             fixed (float* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Sgetrf(MatrixLayout.ColMajor, m, n, pa, lda, ppiv);
+                LapackTest.Sgetrf(m, n, pa, lda, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -62,7 +61,7 @@ namespace MatFlatTest
             fixed (float* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Sgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Sgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -86,7 +85,7 @@ namespace MatFlatTest
             fixed (float* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Sgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Sgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -129,7 +128,7 @@ namespace MatFlatTest
             fixed (double* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Dgetrf(MatrixLayout.ColMajor, m, n, pa, lda, ppiv);
+                LapackTest.Dgetrf(m, n, pa, lda, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -153,7 +152,7 @@ namespace MatFlatTest
             fixed (double* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Dgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Dgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -177,7 +176,7 @@ namespace MatFlatTest
             fixed (double* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Dgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Dgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -220,7 +219,7 @@ namespace MatFlatTest
             fixed (Complex* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Zgetrf(MatrixLayout.ColMajor, m, n, pa, lda, ppiv);
+                LapackTest.Zgetrf(m, n, pa, lda, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -245,7 +244,7 @@ namespace MatFlatTest
             fixed (Complex* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Zgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Zgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();
@@ -270,7 +269,7 @@ namespace MatFlatTest
             fixed (Complex* pa = expectedA)
             fixed (int* ppiv = expectedPiv)
             {
-                Lapack.Zgetrf(MatrixLayout.ColMajor, 3, 3, pa, 3, ppiv);
+                LapackTest.Zgetrf(3, 3, pa, 3, ppiv);
             }
 
             var actualA = a.ToArray();

--- a/MatFlatTest/MatFlatTest.csproj
+++ b/MatFlatTest/MatFlatTest.csproj
@@ -23,8 +23,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="OpenBlasSharp" Version="0.3.4" />
-    <PackageReference Include="OpenBlasSharp.Windows" Version="2026.1.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MatFlatTest/QrTests.cs
+++ b/MatFlatTest/QrTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -45,18 +44,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pq, ldq,
                     pr, ldr,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, m,
                     1.0F,
                     pq, ldq,
@@ -150,18 +147,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pq, ldq,
                     pr, ldr,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, m,
                     1.0F,
                     pq, ldq,
@@ -233,18 +228,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pq, ldq,
                     pr, ldr,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, m,
                     1.0,
                     pq, ldq,
@@ -338,18 +331,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pq, ldq,
                     pr, ldr,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, m,
                     1.0,
                     pq, ldq,
@@ -423,18 +414,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pq, ldq,
                     pr, ldr,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, m,
                     &one,
                     pq, ldq,
@@ -536,18 +525,16 @@ namespace MatFlatTest
                 Factorization.Qr(m, n, pa, lda, prdiag);
                 Factorization.QrOrthogonalFactor(m, n, pa, lda, pq, ldq);
                 Factorization.QrUpperTriangularFactor(m, n, pa, lda, pr, ldr, prdiag);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pq, ldq,
                     pr, ldr,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, m,
                     &one,
                     pq, ldq,

--- a/MatFlatTest/SvdTests.cs
+++ b/MatFlatTest/SvdTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
-using OpenBlasSharp;
 using MatFlat;
 
 namespace MatFlatTest
@@ -62,36 +61,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0F,
                     pu, ldu,
                     psmat, m,
                     0.0F,
                     pus, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pus, m,
                     pvt, ldvt,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0F,
                     pu, ldu,
                     pu, ldu,
                     0.0F,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pvt, ldvt,
@@ -232,36 +227,32 @@ namespace MatFlatTest
                 original.CopyTo(a, 0);
                 Factorization.Svd(m, n, pa, lda, ps, null, 0, pvt, ldvt);
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0F,
                     pu, ldu,
                     psmat, m,
                     0.0F,
                     pus, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pus, m,
                     pvt, ldvt,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0F,
                     pu, ldu,
                     pu, ldu,
                     0.0F,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pvt, ldvt,
@@ -406,36 +397,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0F,
                     pu, ldu,
                     psmat, m,
                     0.0F,
                     pus, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pus, m,
                     pvt, ldvt,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0F,
                     pu, ldu,
                     pu, ldu,
                     0.0F,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pvt, ldvt,
@@ -554,36 +541,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0F,
                     pu, ldu,
                     psmat, m,
                     0.0F,
                     pus, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pus, m,
                     pvt, ldvt,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0F,
                     pu, ldu,
                     pu, ldu,
                     0.0F,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pvt, ldvt,
@@ -682,9 +665,8 @@ namespace MatFlatTest
             fixed (float* psrc1 = src1)
             fixed (float* psrc2 = src2)
             {
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, rank,
                     1.0F,
                     psrc1, m,
@@ -720,36 +702,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0F,
                     pu, ldu,
                     psmat, m,
                     0.0F,
                     pus, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0F,
                     pus, m,
                     pvt, ldvt,
                     0.0F,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0F,
                     pu, ldu,
                     pu, ldu,
                     0.0F,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Sgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Sgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0F,
                     pvt, ldvt,
@@ -884,36 +862,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0,
                     pu, ldu,
                     psmat, m,
                     0.0,
                     pus, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pus, m,
                     pvt, ldvt,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0,
                     pu, ldu,
                     pu, ldu,
                     0.0,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pvt, ldvt,
@@ -1054,36 +1028,32 @@ namespace MatFlatTest
                 original.CopyTo(a, 0);
                 Factorization.Svd(m, n, pa, lda, ps, null, 0, pvt, ldvt);
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0,
                     pu, ldu,
                     psmat, m,
                     0.0,
                     pus, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pus, m,
                     pvt, ldvt,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0,
                     pu, ldu,
                     pu, ldu,
                     0.0,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pvt, ldvt,
@@ -1228,36 +1198,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0,
                     pu, ldu,
                     psmat, m,
                     0.0,
                     pus, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pus, m,
                     pvt, ldvt,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0,
                     pu, ldu,
                     pu, ldu,
                     0.0,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pvt, ldvt,
@@ -1376,36 +1342,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0,
                     pu, ldu,
                     psmat, m,
                     0.0,
                     pus, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pus, m,
                     pvt, ldvt,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0,
                     pu, ldu,
                     pu, ldu,
                     0.0,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pvt, ldvt,
@@ -1504,9 +1466,8 @@ namespace MatFlatTest
             fixed (double* psrc1 = src1)
             fixed (double* psrc2 = src2)
             {
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, rank,
                     1.0,
                     psrc1, m,
@@ -1542,36 +1503,32 @@ namespace MatFlatTest
                     Matrix.Set(m, n, smat, m, i, i, s[i]);
                 }
 
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     1.0,
                     pu, ldu,
                     psmat, m,
                     0.0,
                     pus, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     1.0,
                     pus, m,
                     pvt, ldvt,
                     0.0,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     m, m, m,
                     1.0,
                     pu, ldu,
                     pu, ldu,
                     0.0,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Dgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.Trans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Dgemm(
+                    Transpose.Trans, Transpose.NoTrans,
                     n, n, n,
                     1.0,
                     pvt, ldvt,
@@ -1708,36 +1665,32 @@ namespace MatFlatTest
 
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     &one,
                     pu, ldu,
                     psmat, m,
                     &zero,
                     pus, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pus, m,
                     pvt, ldvt,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     m, m, m,
                     &one,
                     pu, ldu,
                     pu, ldu,
                     &zero,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pvt, ldvt,
@@ -1886,36 +1839,32 @@ namespace MatFlatTest
 
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     &one,
                     pu, ldu,
                     psmat, m,
                     &zero,
                     pus, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pus, m,
                     pvt, ldvt,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     m, m, m,
                     &one,
                     pu, ldu,
                     pu, ldu,
                     &zero,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pvt, ldvt,
@@ -2068,36 +2017,32 @@ namespace MatFlatTest
 
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     &one,
                     pu, ldu,
                     psmat, m,
                     &zero,
                     pus, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pus, m,
                     pvt, ldvt,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     m, m, m,
                     &one,
                     pu, ldu,
                     pu, ldu,
                     &zero,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pvt, ldvt,
@@ -2224,36 +2169,32 @@ namespace MatFlatTest
 
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     &one,
                     pu, ldu,
                     psmat, m,
                     &zero,
                     pus, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pus, m,
                     pvt, ldvt,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     m, m, m,
                     &one,
                     pu, ldu,
                     pu, ldu,
                     &zero,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pvt, ldvt,
@@ -2327,9 +2268,8 @@ namespace MatFlatTest
             {
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, rank,
                     &one,
                     psrc1, m,
@@ -2367,36 +2307,32 @@ namespace MatFlatTest
 
                 var one = Complex.One;
                 var zero = Complex.Zero;
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, m,
                     &one,
                     pu, ldu,
                     psmat, m,
                     &zero,
                     pus, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.NoTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.NoTrans, Transpose.NoTrans,
                     m, n, n,
                     &one,
                     pus, m,
                     pvt, ldvt,
                     &zero,
                     preconstructed, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     m, m, m,
                     &one,
                     pu, ldu,
                     pu, ldu,
                     &zero,
                     pidentity1, m);
-                OpenBlasSharp.Blas.Zgemm(
-                    Order.ColMajor,
-                    OpenBlasSharp.Transpose.ConjTrans, OpenBlasSharp.Transpose.NoTrans,
+                LapackTest.Zgemm(
+                    Transpose.ConjTrans, Transpose.NoTrans,
                     n, n, n,
                     &one,
                     pvt, ldvt,


### PR DESCRIPTION
### Motivation
- テストからネイティブ OpenBlasSharp 依存を取り除き、既に置き換え済みの BLAS テストと同様に `ManagedLAPACK` を使って安定して実行できるようにするため。 
- 行列分解（QR, LU, LU inverse, Cholesky, EVD/GEVD, SVD）で OpenBlasSharp 固有の呼び出しや enum を直接使わないように統一するため。 
- 名前空間衝突を避けつつ MatFlat の `Transpose` 等を使えるようにしてテスト内の冗長なプレフィックスを整理するため。 

### Description
- テスト用ラッパー `MatFlatTest/LapackTest.cs` を追加し、`ManagedLAPACK` (`ILapack`/`ManagedLAPACK`) を用いた `Sgemm/Dgemm/Zgemm`、`Sgemv/Dgemv/Zgemv`（gemv は内部で gemm を利用）、`Sgetrf/Dgetrf/Zgetrf`、`Spotrf/Dpotrf/Zpotrf` を提供するメソッドを実装した。 
- QR, LU, LU inverse, Cholesky, EVD, GEVD, SVD の各テストを修正して `OpenBlasSharp.Blas.*` や `Lapack.*(MatrixLayout.ColMajor, ...)` 呼び出しを `LapackTest.*` と MatFlat の `Transpose` enum ベースの呼び出しに置き換えた。 
- テスト内の `OpenBlasResultToL` を `LapackResultToL` にリネームして対応箇所を更新し、`using OpenBlasSharp;` と `OpenBlasSharp` 関連の package references を `MatFlatTest.csproj` から除去した。 
- 既存の BLAS 変更と同様のスタイルに合わせ、分解テスト群のみを差し替える形で変更を行った（他のテストは OpenBLAS バイナリ依存のためそのまま）。 

### Testing
- 実行したビルドは `dotnet build MatFlatTest/MatFlatTest.csproj --no-restore` でビルドは成功した。 
- 分解テスト群をフィルタして `dotnet test MatFlatTest/MatFlatTest.csproj --no-build --filter "FullyQualifiedName~QrTests|FullyQualifiedName~LuTests|FullyQualifiedName~GevdTests|FullyQualifiedName~CholeskyTests|FullyQualifiedName~LuInverseTests|FullyQualifiedName~EvdTests|FullyQualifiedName~SvdTests"` を実行し、対象のテストはすべて成功して `Failed: 0, Passed: 498, Total: 498` となった。 
- 他のテストは OpenBLAS バイナリを要求するため実行対象から外している。 
- 変換によって既存テストの許容誤差（tolerance）は変更しておらず、もし tolerance を超えて失敗するケースがあれば別途報告が必要である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb38ed1b08326b7bf0df9a59f192b)