### PR TITLE
Add optional tracing for double SVD dispatch and minimal repro program for kase=2

### DIFF
--- a/MatFlat/Factorization.Svd.cs
+++ b/MatFlat/Factorization.Svd.cs
@@ -1076,6 +1076,7 @@ namespace MatFlat
 
                     // Split at negligible s(k).
                     case 2:
+                        TraceDoubleSvdKase(2, m, n, p, k);
                         f = e[k - 1];
                         e[k - 1] = 0.0;
                         for (var j = k; j < p; j++)
@@ -1255,6 +1256,14 @@ namespace MatFlat
 
             var copySize = sizeof(double) * Math.Min(m, n);
             Buffer.MemoryCopy(stmp, s, copySize, copySize);
+        }
+
+        private static void TraceDoubleSvdKase(int kase, int m, int n, int p, int k)
+        {
+            if (Environment.GetEnvironmentVariable("MATFLAT_TRACE_SVD_KASE") == "1")
+            {
+                Console.WriteLine($"MatFlat.Svd<double>: reached case {kase} (m={m}, n={n}, p={p}, k={k})");
+            }
         }
 
         private static unsafe void SvdCore(int m, int n, Complex* a, int lda, double* s, Complex* u, int ldu, Complex* vt, int ldvt, Complex* work, Complex* e, Complex* stmp)

--- a/Workspace/Program.cs
+++ b/Workspace/Program.cs
@@ -1,29 +1,141 @@
 ﻿using System;
+using System.IO;
 using MatFlat;
 
 public static class Program
 {
     public static unsafe void Main(string[] args)
     {
-        var n = 3;
-        var a = new double[n * n];
-
-        for (var i = 0; i < a.Length; i++)
+        // MatFlat stores matrices in column-major order.
+        // This is the 2-by-2 matrix:
+        //     [ 0  1 ]
+        //     [ 0  2 ]
+        // During the double SVD implementation's initial bidiagonal setup, it has
+        // stmp = [0, 2] and e = [1, 0]. Since e[0] is not negligible but stmp[0]
+        // is negligible, the first main-iteration dispatch is kase = 2.
+        const int m = 2;
+        const int n = 2;
+        var a = new double[]
         {
-            a[i] = double.NaN;
+            0.0, 0.0,
+            1.0, 2.0,
+        };
+
+        var initialKase = ComputeInitialSvdKaseForThisExample();
+        Console.WriteLine("Minimal double SVD kase2 example");
+        Console.WriteLine("A = [ [0, 1], [0, 2] ]");
+        Console.WriteLine("column-major storage = [0, 0, 1, 2]");
+        Console.WriteLine("initial bidiagonal stmp = [0, 2], e = [1, 0]");
+        Console.WriteLine($"first main-iteration kase = {initialKase}");
+        Console.WriteLine();
+
+        var s = new double[Math.Min(m, n)];
+        var u = new double[m * m];
+        var vt = new double[n * n];
+
+        var trace = RunSvdAndCaptureKaseTrace(m, n, a, s, u, vt);
+        Console.Write(trace);
+
+        if (!trace.Contains("MatFlat.Svd<double>: reached case 2", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("The actual Factorization.Svd execution did not reach double SVD case 2.");
         }
 
-        var u = new double[n * n];
-        var s = new double[n];
-        fixed (double* pa = a)
-        fixed (double* pu = u)
-        fixed (double* ps = s)
-        {
-            Factorization.Svd(n, n, pa, n, ps, pu, n, null, 0);
-        }
-        foreach (var value in u)
+        Console.WriteLine("Confirmed: actual Factorization.Svd execution reached double SVD case 2.");
+        Console.WriteLine();
+
+        Console.WriteLine("SVD completed. Singular values:");
+        foreach (var value in s)
         {
             Console.WriteLine(value);
         }
+    }
+
+    private static unsafe string RunSvdAndCaptureKaseTrace(int m, int n, double[] a, double[] s, double[] u, double[] vt)
+    {
+        using var writer = new StringWriter();
+        var originalOut = Console.Out;
+        var originalTraceSetting = Environment.GetEnvironmentVariable("MATFLAT_TRACE_SVD_KASE");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MATFLAT_TRACE_SVD_KASE", "1");
+            Console.SetOut(writer);
+
+            fixed (double* pa = a)
+            fixed (double* ps = s)
+            fixed (double* pu = u)
+            fixed (double* pvt = vt)
+            {
+                Factorization.Svd(m, n, pa, m, ps, pu, m, pvt, n);
+            }
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Environment.SetEnvironmentVariable("MATFLAT_TRACE_SVD_KASE", originalTraceSetting);
+        }
+
+        return writer.ToString();
+    }
+
+    private static int ComputeInitialSvdKaseForThisExample()
+    {
+        var stmp = new[] { 0.0, 2.0 };
+        var e = new[] { 1.0, 0.0 };
+        var p = 2;
+        var eps = Math.Pow(2.0, -52.0);
+
+        int k;
+        for (k = p - 2; k >= 0; k--)
+        {
+            if (Math.Abs(e[k]) <= eps * (Math.Abs(stmp[k]) + Math.Abs(stmp[k + 1])))
+            {
+                e[k] = 0.0;
+                break;
+            }
+        }
+
+        int kase;
+        if (k == p - 2)
+        {
+            kase = 4;
+        }
+        else
+        {
+            int ks;
+            for (ks = p - 1; ks > k; ks--)
+            {
+                var t = 0.0;
+                if (ks != p - 1)
+                {
+                    t += Math.Abs(e[ks]);
+                }
+                if (ks != k + 1)
+                {
+                    t += Math.Abs(e[ks - 1]);
+                }
+                if (Math.Abs(stmp[ks]) <= eps * t)
+                {
+                    stmp[ks] = 0.0;
+                    break;
+                }
+            }
+
+            if (ks == k)
+            {
+                kase = 3;
+            }
+            else if (ks == p - 1)
+            {
+                kase = 1;
+            }
+            else
+            {
+                kase = 2;
+            }
+        }
+
+        return kase;
     }
 }


### PR DESCRIPTION
### Motivation
- Enable lightweight tracing of which main-iteration case (`kase`) the double SVD implementation reaches to aid debugging of edge cases.
- Provide a minimal, reproducible workspace program that demonstrates and verifies the SVD reaching case 2 for a small example matrix.

### Description
- Add `TraceDoubleSvdKase(int kase, int m, int n, int p, int k)` which emits a trace line when the `MATFLAT_TRACE_SVD_KASE` environment variable is set to `1`.
- Invoke `TraceDoubleSvdKase` at the start of the double SVD `case 2` dispatch so the runtime will log when that case is taken.
- Add a `Workspace/Program.cs` demonstration that constructs a small 2x2 matrix, computes the expected initial `kase` for that bidiagonal setup, sets the trace environment variable, runs `Factorization.Svd(...)`, captures console output, and asserts that the trace contains the expected "reached case 2" message.
- Add helper methods in the workspace: `RunSvdAndCaptureKaseTrace` to run SVD under tracing and capture output, and `ComputeInitialSvdKaseForThisExample` to compute the initial expected `kase` for the example bidiagonal values.

### Testing
- Ran the workspace program which sets `MATFLAT_TRACE_SVD_KASE=1`, executes the SVD on the minimal example, and verifies that the trace contains `MatFlat.Svd<double>: reached case 2`; this run succeeded with the confirmation printed and no exception thrown.
- No other automated unit tests were changed or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69febda244fc8326a7da4aed73c629dd)