### PR TITLE
Use complex R diagonal/tau in QR factorization and update complex QR routines and tests

### DIFF
--- a/MatFlat/Factorization.Qr.cs
+++ b/MatFlat/Factorization.Qr.cs
@@ -195,7 +195,7 @@ namespace MatFlat
         /// <param name="rdiag">
         /// On exit, the diagonal elements of R are stored.
         /// </param>
-        public static unsafe void Qr(int m, int n, Complex* a, int lda, double* rdiag)
+        public static unsafe void Qr(int m, int n, Complex* a, int lda, Complex* rdiag)
         {
             if (m <= 0)
             {
@@ -232,10 +232,14 @@ namespace MatFlat
             for (var k = 0; k < n; k++)
             {
                 var norm = Internals.Norm(m - k, colk + k);
+                var alpha = Complex.Zero;
 
                 if (norm != 0.0)
                 {
-                    Internals.DivInplace(m - k, colk + k, norm);
+                    var phase = colk[k] == Complex.Zero ? Complex.One : colk[k] / colk[k].Magnitude;
+                    alpha = phase * norm;
+
+                    Internals.DivInplace(m - k, colk + k, alpha);
 
                     colk[k] += 1.0;
 
@@ -243,12 +247,12 @@ namespace MatFlat
                     for (var j = k + 1; j < n; j++)
                     {
                         var colj = a + lda * j;
-                        var s = -Internals.DotConj(m - k, colk + k, colj + k) / colk[k];
+                        var s = -Internals.DotConj(m - k, colk + k, colj + k) / colk[k].Real;
                         Internals.MulAdd(m - k, colk + k, s, colj + k);
                     }
                 }
 
-                rdiag[k] = -norm;
+                rdiag[k] = -alpha;
 
                 colk += lda;
             }
@@ -422,7 +426,7 @@ namespace MatFlat
         /// The number of columns of the source matrix.
         /// </param>
         /// <param name="a">
-        /// The result of the QR decomposition obtained from <see cref="Qr(int, int, Complex*, int, double*)"/>.
+        /// The result of the QR decomposition obtained from <see cref="Qr(int, int, Complex*, int, Complex*)"/>.
         /// </param>
         /// <param name="lda">
         /// The leading dimension of the source array.
@@ -484,8 +488,8 @@ namespace MatFlat
                     var qColj = q + ldq * j;
                     if (aColk[k] != 0)
                     {
-                        var s = -Internals.DotConj(m - k, qColj + k, aColk + k) / aColk[k];
-                        Internals.MulConjAdd(m - k, s, aColk + k, qColj + k);
+                        var s = -Internals.DotConj(m - k, aColk + k, qColj + k) / aColk[k].Real;
+                        Internals.MulAdd(m - k, aColk + k, s, qColj + k);
                     }
                 }
             }
@@ -660,7 +664,7 @@ namespace MatFlat
         /// The number of columns of the source matrix.
         /// </param>
         /// <param name="a">
-        /// The result of the QR decomposition obtained from <see cref="Qr(int, int, Complex*, int, double*)"/>.
+        /// The result of the QR decomposition obtained from <see cref="Qr(int, int, Complex*, int, Complex*)"/>.
         /// </param>
         /// <param name="lda">
         /// The leading dimension of the source array.
@@ -672,9 +676,9 @@ namespace MatFlat
         /// The leading dimension of the array R.
         /// </param>
         /// <param name="rdiag">
-        /// The diagonal elements of R obtained from <see cref="Qr(int, int, Complex*, int, double*)"/>.
+        /// The diagonal elements of R obtained from <see cref="Qr(int, int, Complex*, int, Complex*)"/>.
         /// </param>
-        public static unsafe void QrUpperTriangularFactor(int m, int n, Complex* a, int lda, Complex* r, int ldr, double* rdiag)
+        public static unsafe void QrUpperTriangularFactor(int m, int n, Complex* a, int lda, Complex* r, int ldr, Complex* rdiag)
         {
             if (m <= 0)
             {

--- a/MatFlatTest/QrTests.cs
+++ b/MatFlatTest/QrTests.cs
@@ -395,7 +395,7 @@ namespace MatFlatTest
             var original = Matrix.RandomComplex(42, m, n, lda);
 
             var a = original.ToArray();
-            var rdiag = new double[n];
+            var rdiag = new Complex[n];
             var q = Matrix.RandomComplex(0, m, n, ldq);
             var qCopy = q.ToArray();
             var r = Matrix.RandomComplex(0, n, n, ldr);
@@ -403,7 +403,7 @@ namespace MatFlatTest
             var reconstructed = new Complex[m * n];
             var identity = new Complex[n * n];
             fixed (Complex* pa = a)
-            fixed (double* prdiag = rdiag)
+            fixed (Complex* prdiag = rdiag)
             fixed (Complex* pq = q)
             fixed (Complex* pr = r)
             fixed (Complex* preconstructed = reconstructed)
@@ -506,7 +506,7 @@ namespace MatFlatTest
             var original = new Complex[] { 1, 2, 3, 2 * j, 4 * j, 6 * j, 0, 0, 0 };
 
             var a = original.ToArray();
-            var rdiag = new double[n];
+            var rdiag = new Complex[n];
             var q = Matrix.RandomComplex(0, m, n, ldq);
             var qCopy = q.ToArray();
             var r = Matrix.RandomComplex(0, n, n, ldr);
@@ -514,7 +514,7 @@ namespace MatFlatTest
             var reconstructed = new Complex[m * n];
             var identity = new Complex[n * n];
             fixed (Complex* pa = a)
-            fixed (double* prdiag = rdiag)
+            fixed (Complex* prdiag = rdiag)
             fixed (Complex* pq = q)
             fixed (Complex* pr = r)
             fixed (Complex* preconstructed = reconstructed)


### PR DESCRIPTION
### Motivation
- Correctly handle complex-valued QR factorizations by representing the R diagonal/Householder scale as complex rather than real and fix the reflector application for complex matrices. 

### Description
- Changed the QR API to store diagonal/Householder scale values as `Complex* rdiag` instead of `double* rdiag` for `Qr` and `QrUpperTriangularFactor`, and updated related XML references. 
- Modified the QR factorization to compute a complex `alpha` (phase times norm) and use it when normalizing the Householder vector via `Internals.DivInplace`, and write `-alpha` into `rdiag`. 
- Adjusted application of reflectors in `Qr` and `QrOrthogonalFactor` to use appropriate conjugation/order and to divide by the real part of the leading element when required, replacing uses of `MulConjAdd` with `MulAdd` where the data layout was adapted. 
- Updated `MatFlatTest/QrTests.cs` to allocate `rdiag` as `Complex[]` and pass a `Complex*` to the modified APIs. 

### Testing
- Ran the QR unit tests in `MatFlatTest/QrTests.cs`, including `QrComplex_General` and `QrComplex_Singular`, via the test suite; the modified tests executed and passed. 
- Ran the project test suite (`dotnet test`) to validate API/signature changes and existing matrix tests; the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016bb701b483269c17e0d66dd4696b)